### PR TITLE
Add Iterator[Any] Sink

### DIFF
--- a/src/test/scala/unit/EncodeTuplesSpec.scala
+++ b/src/test/scala/unit/EncodeTuplesSpec.scala
@@ -23,6 +23,7 @@ class EncodeTuplesSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAl
 
   def encodeTuples(input: Seq[Product]): Future[ByteString] = {
     Source.fromIterator(() => input.iterator)
+      .map(_.productIterator)
       .via(PgCopyStreamConverters.encodeTuples(Codec.UTF8))
       .runWith(Sink.fold(ByteString("")) {
         case (acc, next) => acc ++ next


### PR DESCRIPTION
Current version of the code accepts either a Product or a ByteString for copying to database, but this is somewhat limited, in case you have your data as `List[AnyVal]` or other forms.

This adds an Iterator[Any] sink for copying data to postgres, which makes it somewhat easier to take any format of the rows (most data collections can be turned to Iterators of Any, but only a few can be turned to Products). 